### PR TITLE
ビルドターゲットを変更する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es2015",
     "module": "es2015",
     "lib": ["es2015"],
     "strict": true,


### PR DESCRIPTION
#116 でビルドがコケるのは TypeScript 3.6 でスプレッド構文の扱いが変わり、ビルドターゲットを `es5` に設定しているとそのままではコンパイルできないからでした。
良い機会なのでIE11を捨てるつもりで、TypeScript のビルドターゲットを `es2015` に変更したいと思います。
確認お願いします。

